### PR TITLE
FIX: volunteer_handler.py

### DIFF
--- a/src/bot/handlers/volunteer_handler.py
+++ b/src/bot/handlers/volunteer_handler.py
@@ -66,6 +66,7 @@ edit_volunteer_conv = ConversationHandler(
 )
 
 add_volunteer_conv = ConversationHandler(
+    allow_reentry=True,
     name="add_volunteer_conv",
     entry_points=[
         CallbackQueryHandler(


### PR DESCRIPTION
> Сейчас если начать заполнять анкеты и ввести /start, то все перестает работать. Пошаговое пояснение на примере меню “Стать волонтером”:
> 
> 1. Запустить бот
> 2. Нажать на СТАРТ
> 3. Нажать на пункт меню "Хочу стать волонтёром"
> 4. Нажать на кнопку "Начать"
> 5. Ввести "Иванов Иван Иванович", отправить
> 6. Ввести и отправить /start

Ошибка была в **add_volunteer_conv** = ConversationHandler() - allow_reentry.